### PR TITLE
Suspected bug

### DIFF
--- a/scripts/btzen-connect
+++ b/scripts/btzen-connect
@@ -68,7 +68,7 @@ async def connect_devices(service_uuid: str, mac: list[str]) -> None:
     srv = btzen.Service(service_uuid)
     set_trigger = partial(
         btzen.set_trigger,
-        conndition=btzen.TriggerCondition.ON_CHANGE
+        condition=btzen.TriggerCondition.ON_CHANGE
     )
     devices = [set_trigger(btzen.create_device(srv, m)) for m in mac]
     async with btzen.connect(devices):


### PR DESCRIPTION
I just suspect this to be a bug (due to a typo) as the argument `conndition` doesn't seem valid for the `btzen.set_trigger` function and thus I propose to change it to `condition` here. Please note this is just a visual observation and it is NOT tested at all.